### PR TITLE
Update bestpractices.ps1

### DIFF
--- a/bestpractices.ps1
+++ b/bestpractices.ps1
@@ -408,6 +408,7 @@ foreach ($esx in $hosts)
                 $satpArgs.satp = $rule.Name
                 $satpArgs.psp = $rule.DefaultPSP
                 $satpArgs.pspoption = $rule.PSPOptions
+                $satpArgs.boot=$true
                 add-content $logfile "This rule is incorrect, deleting..."
                 $esxcli.storage.nmp.satp.rule.remove.invoke($satpArgs)
                 add-content $logfile "*****NOTE: Deleted the rule.*****"


### PR DESCRIPTION
Fixes issue on remove satp rule:

Message: EsxCLI.CLIFault.summary;
InnerText: Error deleting SATP rule: No rule matching the given options found, nothing to delete. Specify all options for the rule to delete it successfully.: Not
foundEsxCLI.CLIFault.summary